### PR TITLE
feat(JOIN 0): implement user disconnect from all channels

### DIFF
--- a/ircserver/includes/Channel.hpp
+++ b/ircserver/includes/Channel.hpp
@@ -29,6 +29,7 @@ class Channel {
 		const std::string& getTopicCreationTime() const;
 		const std::string& getCreationTime() const;
 		bool isFull() const;
+		bool isEmpty() const;
 		bool requiresPassword() const;
 		bool isInviteOnly() const;
 		bool hasTopic() const;
@@ -43,6 +44,7 @@ class Channel {
 		// Actions
 		void addUser(User* user);
 		void addOperator(User* user);
+		void removeUser(User* user);
 
 		// Helpers
 		bool hasUser(const User* user) const;

--- a/ircserver/includes/Common.hpp
+++ b/ircserver/includes/Common.hpp
@@ -87,6 +87,8 @@ typedef StringMap::const_iterator StringMapConstIterator;
 
 typedef std::list<Channel>::iterator ChannelListIterator;
 typedef std::list<Channel>::const_iterator ChannelListConstIterator;
+typedef std::vector<Channel*>::iterator ChannelVectorIterator;
+typedef std::vector<Channel*>::const_iterator ChannelVectorConstIterator;
 
 typedef std::string::size_type StringSizeT;
 

--- a/ircserver/includes/Parser.hpp
+++ b/ircserver/includes/Parser.hpp
@@ -34,7 +34,7 @@ class Parser {
 		static bool validateNickname(const std::string& nickname);
 
 		// Mappers
-		static StringMap mapJoinCommand(
+		static StringMap mapChanneslWithKeys(
 			const std::string& channelNames,
 			const std::string& channelKeys
 		);

--- a/ircserver/includes/Server.hpp
+++ b/ircserver/includes/Server.hpp
@@ -61,13 +61,16 @@ class Server {
 		void createChannel(User& creator, const std::string& channelName, const std::string& channelKey);
 		void addUserToChannel(User& targetUser, const std::string& channelName, const std::string& channelKey);
 		void sendJoinReplies(const User* user, const Channel* channel);
-		void broadcastJoin(const User* user, const Channel* channel);
+		void broadcastCommand(const User* user, const Channel* channel, const std::string& command);
 		void sendChannelTopic(const User* user, const Channel* channel);
 		void sendChannelUsers(const User* user, const Channel* channel);
 		void sendChannelSetAt(const User* user, const Channel* channel);
+		void partUserFromChannel(User* user, Channel* channel);
+		void removeChannel(Channel* channel);
 
 		// User Utilities
 		User& getUser(int fd);
+		void disconnectUserFromAllChannels(User* user);
 		void sendMessage(int userFd, const std::string &message);
 		void sendNumericReply(
 			const User* user,

--- a/ircserver/includes/User.hpp
+++ b/ircserver/includes/User.hpp
@@ -23,12 +23,14 @@ class User {
 		int getFd() const;
 		const std::string& getNickname() const;
 		std::string getUserIdentifier() const;
+		std::vector<Channel*>& getChannels();
 
 		void setFd(int fd);
 		void setIpAddress(const std::string& ipAddr);
 
 		bool hasChannel(const Channel* channel) const;
 		void addChannel(Channel* channel);
+		void removeChannel(Channel* channel);
 
 	private:
 		int fd;

--- a/ircserver/srcs/Channel.cpp
+++ b/ircserver/srcs/Channel.cpp
@@ -90,6 +90,10 @@ bool Channel::isFull() const {
 	return this->full;
 }
 
+bool Channel::isEmpty() const {
+	return this->usersInChannel <= 0;
+}
+
 bool Channel::requiresPassword() const {
 	return this->hasPassword;
 }
@@ -138,6 +142,28 @@ void Channel::addOperator(User* user) {
 		return;
 	}
 	this->channelOperators.push_back(user);
+}
+
+void Channel::removeUser(User* user) {
+	if (!user) return;
+
+	std::vector<User*>::iterator it = std::remove(
+		channelUsers.begin(),
+		channelUsers.end(),
+		user
+	);
+	if (it != channelUsers.end()) {
+		channelUsers.erase(it, channelUsers.end());
+		this->usersInChannel--;
+	}
+	it = std::remove(
+		channelOperators.begin(),
+		channelOperators.end(),
+		user
+	);
+	if (it != channelOperators.end()) {
+		channelOperators.erase(it, channelOperators.end());
+	}
 }
 
 bool Channel::hasUser(const User* user) const {

--- a/ircserver/srcs/Parser.cpp
+++ b/ircserver/srcs/Parser.cpp
@@ -160,7 +160,7 @@ bool Parser::containsNicknameForbiddenChars(const std::string& input) {
 		) != input.end();
 }
 
-StringMap Parser::mapJoinCommand(
+StringMap Parser::mapChanneslWithKeys(
 	const std::string& channelNames,
 	const std::string& channelKeys
 ) {

--- a/ircserver/srcs/User.cpp
+++ b/ircserver/srcs/User.cpp
@@ -50,6 +50,10 @@ std::string User::getUserIdentifier() const {
 	return nickname + "!" + username + "@" + ipAddress;
 }
 
+std::vector<Channel*>& User::getChannels() {
+	return this->userChannels;
+}
+
 bool User::hasChannel(const Channel* channel) const {
 	if (!channel) return false;
 
@@ -74,4 +78,18 @@ void User::addChannel(Channel* channel) {
 		return;
 	}
 	this->userChannels.push_back(channel);
+}
+
+void User::removeChannel(Channel* channel) {
+	if (!channel) {
+		return;
+	}
+	ChannelVectorIterator it = std::remove(
+		this->userChannels.begin(),
+		this->userChannels.end(),
+		channel
+	);
+	if (it != this->userChannels.end()) {
+		userChannels.erase(it, userChannels.end());
+	}
 }


### PR DESCRIPTION
**PR Description:**
This PR adds support for the special case `JOIN 0`, which disconnects a user from all channels they are currently in.

* Implements `disconnectUserFromAllChannels(User* user)` to iterate through all channels a user is in and remove them safely.
* Adds `partUserFromChannel(User* user, Channel* channel)` to handle the internal logic of leaving a channel, broadcasting the `PART` command, and updating both the user and channel state.
* Ensures that empty channels are automatically removed after users leave.
* Improves code safety by iterating over copies of the user’s channel list to avoid invalidation issues.
