### PR TITLE
feat(disconnect): improve server-user communication, disconnect handling and terminal output

### DIFF
--- a/ircserver/includes/Channel.hpp
+++ b/ircserver/includes/Channel.hpp
@@ -33,6 +33,7 @@ class Channel {
 		bool isOperator(const User* user) const;
 		bool hasTopic() const;
 		bool isTopicProtected() const;
+		bool hasNoOperator() const;
 		bool hasUser(const User* user) const;
 
 		// Setters

--- a/ircserver/includes/Common.hpp
+++ b/ircserver/includes/Common.hpp
@@ -54,6 +54,7 @@ enum CommandType {
 	CMD_PART,
 	CMD_QUIT,
 	CMD_WHO,
+	CMD_PING,
 	CMD_UNKNOWN
 };
 

--- a/ircserver/includes/Parser.hpp
+++ b/ircserver/includes/Parser.hpp
@@ -36,6 +36,12 @@ class Parser {
 		static std::string numericReplyToString(NumericReply numericCode);
 		static bool isValidChannelPrefix(char c);
 
+		// Utility helpers
+		static std::list<std::string> splitStringToList(
+			const std::string& values,
+			const std::string& delimiter
+		);
+
 		// DEBUG
 		static void debugPrintUsers(const std::vector<User*>& users);
 		static void debugPrintChannels(const std::vector<Channel*>& channels);
@@ -52,12 +58,6 @@ class Parser {
 		// Channel name validation helpers
 		static bool isChannelForbiddenChar(char c);
 		static bool containsChannelForbiddenChars(const std::string& input);
-
-		// Utility helpers
-		static std::list<std::string> splitStringToList(
-			const std::string& values,
-			const std::string& delimiter
-		);
 };
 
 #endif

--- a/ircserver/includes/Server.hpp
+++ b/ircserver/includes/Server.hpp
@@ -49,6 +49,7 @@ class Server {
 		void handleUserCommand(User &user, std::string cmdParameters);
 		void handleJoinCommand(User &user, const std::string& commandParams);
 		void handleTopicCommand(User &user, const std::string& commandParams);
+		void handlePartCommand(User &user, const std::string& commandParams);
 		void handleQuitCommand(User &user, const std::string& commandParams);
 		void handlePingQuery(User &user, const std::string& commandParams);
 		void handleWhoQuery(User &user, const std::string& commandParams);
@@ -60,7 +61,7 @@ class Server {
 		void addUserToChannel(User& targetUser, const std::string& channelName, const std::string& channelKey);
 		void sendJoinReplies(const User* user, const Channel* channel);
 		void broadcastCommand(
-			const User* user,
+			const std::string& identifier,
 			const Channel* channel,
 			const std::string& command,
 			const std::string& message
@@ -72,7 +73,7 @@ class Server {
 		void partUserFromChannel(
 			User* user, Channel* channel,
 			bool quit,
-			const std::string& quitReason
+			const std::string& reason
 		);
 		void disconnectUserFromAllChannels(
 			User* user,

--- a/ircserver/includes/Server.hpp
+++ b/ircserver/includes/Server.hpp
@@ -37,7 +37,6 @@ class Server {
 
 		// Lifecycle & Core Setup
 		void serverSocketCreate();
-		void clearUserFromPoll(int fd);
 
 		// Connection Handling
 		void acceptNewUser();
@@ -50,8 +49,9 @@ class Server {
 		void handleUserCommand(User &user, std::string cmdParameters);
 		void handleJoinCommand(User &user, const std::string& commandParams);
 		void handleTopicCommand(User &user, const std::string& commandParams);
-		void handleWhoQuery(User &user, const std::string& commandParams);
+		void handleQuitCommand(User &user, const std::string& commandParams);
 		void handlePingQuery(User &user, const std::string& commandParams);
+		void handleWhoQuery(User &user, const std::string& commandParams);
 
 		// Channel Utilities
 		Channel& getChannel(User& targetUser, const std::string& channelName);
@@ -69,7 +69,16 @@ class Server {
 		void sendChannelUsers(const User* user, const Channel* channel);
 		void sendChannelSetAt(const User* user, const Channel* channel);
 		void replyToChannelWho(const User* user, const Channel* channel);
-		void partUserFromChannel(User* user, Channel* channel);
+		void partUserFromChannel(
+			User* user, Channel* channel,
+			bool quit,
+			const std::string& quitReason
+		);
+		void disconnectUserFromAllChannels(
+			User* user,
+			bool quit,
+			const std::string& quitReason
+		);
 		void removeChannel(Channel* channel);
 
 		// User Utilities
@@ -78,7 +87,8 @@ class Server {
 		bool nicknameExists(const std::string& nickname) const;
 		void registerUser(User &user);
 		void replyToUserWho(const User* askingUser, const User* targetUser);
-		void disconnectUserFromAllChannels(User* user);
+		void clearUser(int fd);
+		void disconnectUser(int fd);
 
 		// Message to Clients
 		void sendMessage(int userFd, const std::string &message);

--- a/ircserver/includes/Server.hpp
+++ b/ircserver/includes/Server.hpp
@@ -51,6 +51,7 @@ class Server {
 		void handleJoinCommand(User &user, const std::string& commandParams);
 		void handleTopicCommand(User &user, const std::string& commandParams);
 		void handleWhoQuery(User &user, const std::string& commandParams);
+		void handlePingQuery(User &user, const std::string& commandParams);
 
 		// Channel Utilities
 		Channel& getChannel(User& targetUser, const std::string& channelName);

--- a/ircserver/srcs/Channel.cpp
+++ b/ircserver/srcs/Channel.cpp
@@ -103,6 +103,10 @@ bool Channel::isTopicProtected() const {
 	return std::find(channelModes.begin(), channelModes.end(), TOPIC_MODE) != channelModes.end();
 }
 
+bool Channel::hasNoOperator() const {
+	return this->channelOperators.empty();
+}
+
 bool Channel::hasUser(const User* user) const {
 	if (!user) return false;
 

--- a/ircserver/srcs/Parser.cpp
+++ b/ircserver/srcs/Parser.cpp
@@ -77,6 +77,7 @@ CommandType Parser::getCommandType(const std::string& command) {
 		commands["MODE"] = CMD_MODE;
 		commands["PART"] = CMD_PART;
 		commands["QUIT"] = CMD_QUIT;
+		commands["PING"] = CMD_PING;
 		commands["WHO"] = CMD_WHO;
 	}
 

--- a/ircserver/srcs/Server.cpp
+++ b/ircserver/srcs/Server.cpp
@@ -107,7 +107,7 @@ void Server::serverSocketCreate() {
 void Server::closeFds() {
 	// Close all Users
 	for (UserListIterator it = users.begin() ; it != users.end() ; ++it) {
-		std::cout << RED << "User <" << it->getFd() << "> Disconnected" << WHITE << "\n";
+		std::cout << RED << "User <" << it->getFd() << "> Disconnected" << WHITE << std::endl;
 		close(it->getFd());
 	}
 	// Close server socket
@@ -182,7 +182,7 @@ void Server::receiveNewData(int fd) {
 	}
 
 	buffer[bytes] = '\0';
-	std::cout << YELLOW << "User <" << fd << "> Data: " << WHITE << buffer;
+	std::cout << YELLOW << "User <" << fd << "> Data: " << WHITE << buffer << std::endl;
 	try {
 		handleRawMessage(fd, buffer);
 	} catch (const std::exception& e) {
@@ -236,6 +236,9 @@ void Server::handleRawMessage(int fd, const char *buffer) {
 		case CMD_PART:
 			break;
 		case CMD_QUIT:
+			break;
+		case CMD_PING:
+			handlePingQuery(user, params);
 			break;
 		case CMD_WHO:
 			handleWhoQuery(user, params);

--- a/ircserver/srcs/Server.cpp
+++ b/ircserver/srcs/Server.cpp
@@ -7,7 +7,7 @@
 bool Server::signal = false;
 
 Server::Server()
-	: name("ft_irc")
+	: name("irc:chat:42")
 	, serverSocketFd(-1)
 	, serverPort(-1)
 	, serverPassword()
@@ -214,6 +214,7 @@ void Server::handleRawMessage(int fd, const char *buffer) {
 		case CMD_MODE:
 			break;
 		case CMD_PART:
+			handlePartCommand(user, params);
 			break;
 		case CMD_QUIT:
 			handleQuitCommand(user, params);

--- a/ircserver/srcs/Server.cpp
+++ b/ircserver/srcs/Server.cpp
@@ -27,7 +27,7 @@ void Server::serverInit(const std::string& port, const std::string& password) {
 	serverSocketCreate();
 
 	std::cout << GREEN << "Server <" << serverSocketFd << "> Connected" << WHITE << std::endl;
-	std::cout << "Waiting to accept a connection...\n";
+	std::cout << "Waiting to accept a connection...\n" << RESET << std::endl;
 
 	// Run Server until a signal is received
 	while (Server::signal == false) {
@@ -107,12 +107,12 @@ void Server::serverSocketCreate() {
 void Server::closeFds() {
 	// Close all Users
 	for (UserListIterator it = users.begin() ; it != users.end() ; ++it) {
-		std::cout << RED << "User <" << it->getFd() << "> Disconnected" << WHITE << std::endl;
+		std::cout << RED << "User <" << it->getFd() << "> Disconnected" << WHITE << RESET  << std::endl;
 		close(it->getFd());
 	}
 	// Close server socket
 	if (serverSocketFd != -1) {
-		std::cout << RED << "Server <" << serverSocketFd << "> Disconnected" << WHITE << std::endl;
+		std::cout << RED << "Server <" << serverSocketFd << "> Disconnected" << WHITE << RESET << std::endl;
 		close(serverSocketFd);
 	}
 }
@@ -161,7 +161,7 @@ void Server::acceptNewUser() {
 	users.push_back(newUser);
 	pollFds.push_back(newPoll);
 
-	std::cout << GREEN << "User <" << incomingFd << "> Connected" << WHITE << std::endl;
+	std::cout << GREEN << "User <" << incomingFd << "> Connected" << WHITE << RESET << std::endl;
 }
 
 void Server::receiveNewData(int fd) {
@@ -175,14 +175,14 @@ void Server::receiveNewData(int fd) {
 
 	// Check if User is disconnected
 	if (bytes <= 0) {
-		std::cout << RED << "User <" << fd << "> Disconnected" << WHITE << std::endl;
+		std::cout << RED << "User <" << fd << "> Disconnected" << WHITE << RESET << std::endl;
 		clearUserFromPoll(fd);
 		close(fd);
 		return;
 	}
 
 	buffer[bytes] = '\0';
-	std::cout << YELLOW << "User <" << fd << "> Data: " << WHITE << buffer << std::endl;
+	std::cout << YELLOW << "User <" << fd << "> Data: " << WHITE << buffer << RESET << std::endl;
 	try {
 		handleRawMessage(fd, buffer);
 	} catch (const std::exception& e) {

--- a/ircserver/srcs/Server.cpp
+++ b/ircserver/srcs/Server.cpp
@@ -237,11 +237,11 @@ void Server::sendMessage(int userFd, const std::string &message) {
 	// IRC messages must end with CRLF
 	std::string messageToSend = message + "\r\n";
 
-	ssize_t bytesSent = send(userFd, messageToSend.c_str(), messageToSend.size(), 0);
+	ssize_t bytesSent = send(userFd, messageToSend.c_str(), messageToSend.size(), MSG_NOSIGNAL);
 	std::cout << "[DEBUG!] Sending:\n" << messageToSend << "To user: " << userFd << "!\n";
 	if (bytesSent == -1) {
 		std::cerr << "Failed to send message to fd " << userFd << std::endl;
-		// TODO Handle Disconnect???
+		disconnectUser(userFd);
 	}
 }
 

--- a/ircserver/srcs/ServerChannelUtils.cpp
+++ b/ircserver/srcs/ServerChannelUtils.cpp
@@ -50,12 +50,15 @@ void Server::createChannel(
 		joinedChannel->setPassword(channelKey);
 	}
 	joinedChannel->addUser(&creator);
-	joinedChannel->addOperator(&creator);
-
 	creator.addChannel(joinedChannel);
 
 	sendJoinReplies(&creator, joinedChannel);
+
+	joinedChannel->addOperator(&creator);
+	std::string modeCommand = channelName + " +o " + creator.getNickname();
+	broadcastCommand(this->name, joinedChannel, "MODE", modeCommand);
 	std::cout << "Channel " << channelName << " created by user " << creator.getFd() << "\n";
+	debugPrintUsersAndChannels();
 }
 
 void Server::addUserToChannel(
@@ -101,22 +104,22 @@ void Server::sendJoinReplies(const User* user, const Channel* channel) {
 	if (!user || !channel) {
 		return ;
 	}
-	broadcastCommand(user, channel, "JOIN", channel->getName());
+	broadcastCommand(user->getUserIdentifier(), channel, "JOIN", channel->getName());
 	sendChannelTopic(user, channel);
 	sendChannelUsers(user, channel);
 	sendChannelSetAt(user, channel);
 }
 
 void Server::broadcastCommand(
-	const User* user,
+	const std::string& identifier,
 	const Channel* channel,
 	const std::string& command,
 	const std::string& message
 ) {
-	if (!user || !channel) {
+	if (!channel) {
 		return ;
 	}
-	std::string commandMessage = ":" + user->getUserIdentifier()
+	std::string commandMessage = ":" + identifier
 		+ " " + command;
 
 	if (!message.empty()) {
@@ -213,15 +216,18 @@ void Server::replyToChannelWho(const User* user, const Channel* channel) {
 void Server::partUserFromChannel(
 	User* user, Channel* channel,
 	bool quit,
-	const std::string& quitReason
+	const std::string& reason
 ) {
 	if (!user || !channel) {
 		return ;
 	}
 	if (quit) {
-		broadcastCommand(user, channel, "QUIT", quitReason);
+		broadcastCommand(user->getUserIdentifier(), channel, "QUIT", reason);
 	} else {
-		broadcastCommand(user, channel, "PART", channel->getName());
+		std::string partMessage = !reason.empty()
+			? channel->getName() + " " + reason
+			: channel->getName();
+		broadcastCommand(user->getUserIdentifier(), channel, "PART", partMessage);
 	}
 	channel->removeUser(user);
 	user->removeChannel(channel);
@@ -229,6 +235,13 @@ void Server::partUserFromChannel(
 		this->removeChannel(channel);
 		return;
 	}
+	if (channel->hasNoOperator()) {
+		User& firstUser = *channel->getUsers().front();
+		channel->addOperator(&firstUser);
+		std::string modeCommand = channel->getName() + " +o " + firstUser.getNickname();
+		broadcastCommand(this->name, channel, "MODE", modeCommand);
+	}
+	// debugPrintUsersAndChannels();
 }
 
 void Server::disconnectUserFromAllChannels(
@@ -240,16 +253,15 @@ void Server::disconnectUserFromAllChannels(
 		return;
 	}
 	std::vector<Channel*> userChannelCopies = user->getChannels();
+	// debugPrintUsersAndChannels();
 	for (
 		ChannelVectorIterator channelIt = userChannelCopies.begin();
 		channelIt != userChannelCopies.end();
 		++channelIt
 	) {
-		debugPrintUsersAndChannels();
 		partUserFromChannel(user, *channelIt, quit, quitReason);
 	}
 	user->getChannels().clear();
-	debugPrintUsersAndChannels();
 }
 
 void Server::removeChannel(Channel* channel) {

--- a/ircserver/srcs/ServerCommandUtils.cpp
+++ b/ircserver/srcs/ServerCommandUtils.cpp
@@ -39,7 +39,7 @@ void Server::handlePassCommand(User &user, std::string cmdParameters){
 
 	// 4 - Adicionar ao user.password
 	user.setPassword(password);
-	std::cout << "✅ User Password Registered Successfully: " << user.getPassword() << std::endl;
+	std::cout << "✅ User Password Registered Successfully: " << user.getPassword() << RESET << std::endl;
 }
 
 // TODO Verificar se forem múltiplos parâmetros, aceitar só o primeiro
@@ -72,7 +72,7 @@ void Server::handleNickCommand(User &user, std::string cmdParameters) {
 
 	// Adicionar nickname ao user
 	user.setNickname(nickname);
-	std::cout << "✅ User Nickname Registered Successfully: " << user.getNickname() << std::endl;
+	std::cout << "✅ User Nickname Registered Successfully: " << user.getNickname() << RESET << std::endl;
 	registerUser(user);
 }
 
@@ -121,7 +121,7 @@ void Server::handleUserCommand(User &user, std::string cmdParameters){
 
 	user.setUsername(username);
 	user.setRealname(realname);
-	std::cout << "✅ User Username + Realname Registered Successfully: " << user.getUsername() << " " << user.getRealname() << std::endl;
+	std::cout << "✅ User Username + Realname Registered Successfully: " << user.getUsername() << RESET << " " << user.getRealname() << std::endl;
 	registerUser(user);
 }
 

--- a/ircserver/srcs/ServerCommandUtils.cpp
+++ b/ircserver/srcs/ServerCommandUtils.cpp
@@ -227,3 +227,14 @@ void Server::handleWhoQuery(User &user, const std::string& commandParams) {
 		std::cerr << "WHO: " << e.what() << std::endl;
 	}
 }
+
+void Server::handlePingQuery(User &user, const std::string& commandParams) {
+	if (commandParams.empty()) {
+		Parser::ft_error("empty: '" + commandParams + "' command");
+		sendNumericReply(&user, ERR_NEEDMOREPARAMS, commandParams + " :Not enough parameters");
+		return;
+	}
+	std::string reference = Parser::extractFirstParam(commandParams);
+	std::string reply = "PONG " + reference;
+	sendMessage(user.getFd(), reply);
+}

--- a/ircserver/srcs/ServerUserUtils.cpp
+++ b/ircserver/srcs/ServerUserUtils.cpp
@@ -60,7 +60,7 @@ void Server::registerUser(User &user) {
 		user.setRegistered(true); //passa para registrado
 
 		std::cout << "🥳 Client " << user.getNickname()
-			<< " fully registred!" << std::endl;
+			<< " fully registred!" << RESET << std::endl;
 		user.setUserIdentifier();
 
 		std::string welcomeUserMessage =


### PR DESCRIPTION
This PR introduces several improvements to user disconnect handling and server debugging output:

* **Reply to PING queries:** Ensures clients receive a proper PONG response.
* **Handle QUIT and disconnect:** Safely remove users from channels, broadcast QUIT messages, and clean up file descriptors.
* **Handle PART command and operator promotion:** When a user leaves a channel, broadcasts PART messages and promotes the next user to operator if necessary, notifying clients of operator status.
* **Broadcast Mode command** on channel creation with operator promotion.
* **Fix terminal colors reset:** Ensures debug prints and logs properly reset console colors after printing.

These changes improve server stability during disconnects and enhance clarity of debug output.
